### PR TITLE
Rename to gitlab-ce, add initial unit tests, switch http_port to an integer in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv/
 build/
 *.charm
+*.swp
 
 .coverage
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A juju operator charm for a Kubernetes deployment and operation of GitLab
 Community Edition.
 
-Charmhub page: https://charmhub.io/gitlab-ce-operator  
-Documentation: https://charmhub.io/gitlab-ce-operator/docs  
+Charmhub page: https://charmhub.io/gitlab-ce
+Documentation: https://charmhub.io/gitlab-ce-/docs
 Bugs / Issues: https://github.com/mkissam/charm-gitlab-ce-operator/issues
 
 ## Description
@@ -25,18 +25,16 @@ next section):
 
 ```bash
 # Deploy the GitLab CE charm
-$ juju deploy gitlab-ce-operator gitlab-ce \
-    --config external_url="gitlab-ce-demo.juju"
+$ juju deploy gitlab-ce
 
 # Deploy the ingress integrator charm
-$ juju deploy nginx-ingress-integrator ingress \
-    --config ingress-class="public"
+$ juju deploy nginx-ingress-integrator ingress
 
 # Relate gitlab-ce and ingress integrator
 $ juju relate gitlab-ce:ingress ingress:ingress
 
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 gitlab-ce-demo.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 gitlab-ce" | sudo tee -a /etc/hosts
 
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color
@@ -45,7 +43,7 @@ $ watch -n1 --color juju status --color
 The initial gitlab preparation takes around 3-4 minutes, before the web ui
 is properly showing up and everything is settled.
 
-Open the http://gitlab-ce-demo.juju url in your browser, and register a new
+Open the `http://gitlab-ce` URL in your browser, and register a new
 administrator password. You can login now as 'root' using the new password.
 
 ## Development Setup
@@ -96,19 +94,17 @@ $ git clone https://github.com/mkissam/charm-gitlab-ce-operator && cd charm-gitl
 $ charmcraft pack
 
 # Deploy!
-$ juju deploy ./gitlab-ce-operator.charm gitlab-ce \
+$ juju deploy ./gitlab-ce.charm \
     --resource gitlab-image=gitlab/gitlab-ce \
-    --config external_url="gitlab-ce-demo.juju"
 
 # Deploy the ingress integrator
 $ juju deploy nginx-ingress-integrator ingress \
-    --config ingress-class="public"
 
 # Relate our app to the ingress
 $ juju relate gitlab-ce:ingress ingress:ingress
 
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 gitlab-ce-demo.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 gitlab-ce" | sudo tee -a /etc/hosts
 
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color

--- a/config.yaml
+++ b/config.yaml
@@ -3,13 +3,13 @@
 
 options:
   external_url:
-    "type": "string"
-    "description": "The FQDN for your GitLab unit"
-    "default": !!null ""
+    type: string
+    description: "The FQDN for your GitLab unit. If unset, the name of the deployed application will be used."
+    default: ""
   http_port:
-    "type": "string"
-    "description": "The HTTP port"
-    "default": "80"
+    type: int
+    description: "The HTTP port"
+    default: 80
   tls_secret_name:
     type: string
     description: "The Kubernetes TLS secret resource name."

--- a/docs/02-quickstart.md
+++ b/docs/02-quickstart.md
@@ -5,23 +5,21 @@ deploy the charm and relate it to an ingress controller:
 
 ```bash
 # Deploy the GitLab CE charm
-$ juju deploy gitlab-ce-operator \
-    --config external_url="gitlab-ce-demo.juju"
+$ juju deploy gitlab-ce
 
 # Deploy the ingress integrator charm
-$ juju deploy nginx-ingress-integrator ingress \
-    --config ingress-class="public"
+$ juju deploy nginx-ingress-integrator ingress
 
 # Relate gitlab-ce and ingress integrator
 $ juju relate gitlab-ce:ingress ingress:ingress
 
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 gitlab-ce-demo.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 gitlab-ce" | sudo tee -a /etc/hosts
 
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color
 ```
 
-Open the http://gitlab-ce-demo.juju url in your browser, and register a new
+Open the `http://gitlab-ce` URL in your browser, and register a new
 administrator password. You can login now as 'root' using the new password.
 

--- a/docs/04-future-plans.md
+++ b/docs/04-future-plans.md
@@ -38,7 +38,7 @@ creation. The password should be a random password, and retrieved by the
 get-initial-password action.
 
 ```
-juju run gitlab-ce-operator --wait get-initial-password
+juju run gitlab-ce --wait get-initial-password
 ```
 
 ## Implement external redis support

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 # Copyright 2021 Ubuntu
 # See LICENSE file for licensing details.
-name: gitlab-ce-operator
+name: gitlab-ce
 display-name: GitLab CE Operator
 summary: GitLab CE juju operator charm for Kubernetes
 description: |

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -14,3 +14,41 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(GitlabCEOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+
+    def test_external_url(self):
+        self.assertEqual(self.harness.charm._external_url, "gitlab-ce")
+
+    def test_ingress_config(self):
+        expected = {
+            "service-hostname": "gitlab-ce",
+            "service-name": "gitlab-ce",
+            "service-port": 80,
+        }
+        self.assertEqual(self.harness.charm.ingress_config, expected)
+        # And now test with a TLS secret name set.
+        self.harness.disable_hooks()
+        self.harness.update_config({"tls_secret_name": "gitlab-tls"})
+        expected["tls-secret-name"] = "gitlab-tls"
+        self.assertEqual(self.harness.charm.ingress_config, expected)
+
+    def test_gitlab_layer(self):
+        conf = ("external_url 'http://gitlab-ce:80'; "
+                "alertmanager['enable']=false; "
+                "prometheus['enable']=false; "
+                "gitlab_rails['smtp_enable']=true; "
+                "gitlab_rails['smtp_enable_starttls_auto']=true; "
+                "gitlab_rails['smtp_tls']=false")
+        expected = {
+            "summary": "gitlab layer",
+            "description": "pebble config layer for gitlab",
+            "services": {
+                "gitlab": {
+                    "override": "replace",
+                    "summary": "gitlab",
+                    "command": "bash -c \"/assets/gitlab-install\"",
+                    "startup": "enabled",
+                    "environment": {"GITLAB_OMNIBUS_CONFIG": conf},
+                }
+            },
+        }
+        self.assertEqual(self.harness.charm._gitlab_layer(), expected)


### PR DESCRIPTION
This renames the charm to gitlab-ce, which will mean needing to register that as a new name on charmhub and uploading the charm to that location once finished.

Some other included changes:
 * Updated default external_url to be determined based on application name to avoid users needing to set that in the simplest case
 * Added initial unit tests
 * Switched http_port to int from string in config.yaml
 * Simplified some of the assembly of ingress config
 * Deferred config-changed event handler if pebble isn't ready yet to avoid error state on deployment
 * Used a context manager to open file for pushing to container
 * Removed unused StoredState

I've deployed this locally in MicroK8s with juju 2.9.4 to confirm it works as expected. It does take a little while after juju reports active/idle status for the service to actually be up while Gitlab is running the Chef recipes in the background, so a nice future improvement will be figuring out how to check Gitlab is actually running before reporting that status.
