### PR TITLE
Adds the gitlab provider relation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 venv/
 build/
 *.charm
+*.swp
 
 .coverage
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A juju operator charm for a Kubernetes deployment and operation of GitLab
 Community Edition.
 
-Charmhub page: https://charmhub.io/gitlab-ce-operator  
-Documentation: https://charmhub.io/gitlab-ce-operator/docs  
+Charmhub page: https://charmhub.io/gitlab-ce
+Documentation: https://charmhub.io/gitlab-ce-/docs
 Bugs / Issues: https://github.com/mkissam/charm-gitlab-ce-operator/issues
 
 ## Description
@@ -25,18 +25,16 @@ next section):
 
 ```bash
 # Deploy the GitLab CE charm
-$ juju deploy gitlab-ce-operator gitlab-ce \
-    --config external_url="gitlab-ce-demo.juju"
+$ juju deploy gitlab-ce
 
 # Deploy the ingress integrator charm
-$ juju deploy nginx-ingress-integrator ingress \
-    --config ingress-class="public"
+$ juju deploy nginx-ingress-integrator ingress
 
 # Relate gitlab-ce and ingress integrator
 $ juju relate gitlab-ce:ingress ingress:ingress
 
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 gitlab-ce-demo.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 gitlab-ce" | sudo tee -a /etc/hosts
 
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color
@@ -45,7 +43,7 @@ $ watch -n1 --color juju status --color
 The initial gitlab preparation takes around 3-4 minutes, before the web ui
 is properly showing up and everything is settled.
 
-Open the http://gitlab-ce-demo.juju url in your browser, and register a new
+Open the `http://gitlab-ce` URL in your browser, and register a new
 administrator password. You can login now as 'root' using the new password.
 
 ## Development Setup
@@ -96,19 +94,17 @@ $ git clone https://github.com/mkissam/charm-gitlab-ce-operator && cd charm-gitl
 $ charmcraft pack
 
 # Deploy!
-$ juju deploy ./gitlab-ce-operator.charm gitlab-ce \
+$ juju deploy ./gitlab-ce.charm \
     --resource gitlab-image=gitlab/gitlab-ce \
-    --config external_url="gitlab-ce-demo.juju"
 
 # Deploy the ingress integrator
 $ juju deploy nginx-ingress-integrator ingress \
-    --config ingress-class="public"
 
 # Relate our app to the ingress
 $ juju relate gitlab-ce:ingress ingress:ingress
 
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 gitlab-ce-demo.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 gitlab-ce" | sudo tee -a /etc/hosts
 
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,16 @@
+# Copyright 2021 Canonical
+# See LICENSE file for licensing details.
+
+type: "charm"
+bases:
+  - build-on:
+    - name: "ubuntu"
+      channel: "20.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "20.04"
+
+parts:
+  charm:
+    build-packages:
+      - git

--- a/config.yaml
+++ b/config.yaml
@@ -3,13 +3,13 @@
 
 options:
   external_url:
-    "type": "string"
-    "description": "The FQDN for your GitLab unit"
-    "default": !!null ""
+    type: string
+    description: "The FQDN for your GitLab unit. If unset, the name of the deployed application will be used."
+    default: ""
   http_port:
-    "type": "string"
-    "description": "The HTTP port"
-    "default": "80"
+    type: int
+    description: "The HTTP port"
+    default: 80
   tls_secret_name:
     type: string
     description: "The Kubernetes TLS secret resource name."

--- a/docs/02-quickstart.md
+++ b/docs/02-quickstart.md
@@ -5,23 +5,21 @@ deploy the charm and relate it to an ingress controller:
 
 ```bash
 # Deploy the GitLab CE charm
-$ juju deploy gitlab-ce-operator \
-    --config external_url="gitlab-ce-demo.juju"
+$ juju deploy gitlab-ce
 
 # Deploy the ingress integrator charm
-$ juju deploy nginx-ingress-integrator ingress \
-    --config ingress-class="public"
+$ juju deploy nginx-ingress-integrator ingress
 
 # Relate gitlab-ce and ingress integrator
 $ juju relate gitlab-ce:ingress ingress:ingress
 
 # Add an entry to /etc/hosts
-$ echo "127.0.1.1 gitlab-ce-demo.juju" | sudo tee -a /etc/hosts
+$ echo "127.0.1.1 gitlab-ce" | sudo tee -a /etc/hosts
 
 # Wait for the deployment to complete
 $ watch -n1 --color juju status --color
 ```
 
-Open the http://gitlab-ce-demo.juju url in your browser, and register a new
+Open the `http://gitlab-ce` URL in your browser, and register a new
 administrator password. You can login now as 'root' using the new password.
 

--- a/docs/04-future-plans.md
+++ b/docs/04-future-plans.md
@@ -38,7 +38,7 @@ creation. The password should be a random password, and retrieved by the
 get-initial-password action.
 
 ```
-juju run gitlab-ce-operator --wait get-initial-password
+juju run gitlab-ce --wait get-initial-password
 ```
 
 ## Implement external redis support

--- a/lib/charms/observability_libs/v0/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v0/kubernetes_service_patch.py
@@ -1,0 +1,280 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# KubernetesServicePatch Library.
+
+This library is designed to enable developers to more simply patch the Kubernetes Service created
+by Juju during the deployment of a sidecar charm. When sidecar charms are deployed, Juju creates a
+service named after the application in the namespace (named after the Juju model). This service by
+default contains a "placeholder" port, which is 65536/TCP.
+
+When modifying the default set of resources managed by Juju, one must consider the lifecycle of the
+charm. In this case, any modifications to the default service (created during deployment), will
+be overwritten during a charm upgrade.
+
+When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
+events which applies the patch to the cluster. This should ensure that the service ports are
+correct throughout the charm's life.
+
+The constructor simply takes a reference to the parent charm, and a list of tuples that each define
+a port for the service, where each tuple contains:
+
+- a name for the port
+- port for the service to listen on
+- optionally: a targetPort for the service (the port in the container!)
+- optionally: a nodePort for the service (for NodePort or LoadBalancer services only!)
+- optionally: a name of the service (in case service name needs to be patched as well)
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`. **Note
+that you also need to add `lightkube` and `lightkube-models` to your charm's `requirements.txt`.**
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.observability_libs.v0.kubernetes_service_patch
+echo <<-EOF >> requirements.txt
+lightkube
+lightkube-models
+EOF
+```
+
+Then, to initialise the library:
+
+For ClusterIP services:
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.service_patcher = KubernetesServicePatch(self, [(f"{self.app.name}", 8080)])
+    # ...
+```
+
+For LoadBalancer/NodePort services:
+```python
+# ...
+from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.service_patcher = KubernetesServicePatch(
+        self, [(f"{self.app.name}", 443, 443, 30666)], "LoadBalancer"
+    )
+    # ...
+```
+
+Additionally, you may wish to use mocks in your charm's unit testing to ensure that the library
+does not try to make any API calls, or open any files during testing that are unlikely to be
+present, and could break your tests. The easiest way to do this is during your test `setUp`:
+
+```python
+# ...
+
+@patch("charm.KubernetesServicePatch", lambda x, y: None)
+def setUp(self, *unused):
+    self.harness = Harness(SomeCharm)
+    # ...
+```
+"""
+
+import logging
+from types import MethodType
+from typing import Literal, Sequence, Tuple, Union
+
+from lightkube import ApiError, Client
+from lightkube.models.core_v1 import ServicePort, ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
+from lightkube.types import PatchType
+from ops.charm import CharmBase
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0042f86d0a874435adef581806cddbbb"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 6
+
+PortDefinition = Union[Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]]
+ServiceType = Literal["ClusterIP", "LoadBalancer"]
+
+
+class KubernetesServicePatch(Object):
+    """A utility for patching the Kubernetes service set up by Juju."""
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ):
+        """Constructor for KubernetesServicePatch.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            ports: a list of tuples (name, port, targetPort, nodePort) for every service port.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
+        """
+        super().__init__(charm, "kubernetes-service-patch")
+        self.charm = charm
+        self.service_name = service_name if service_name else self._app
+        self.service = self._service_object(
+            ports,
+            service_name,
+            service_type,
+            additional_labels,
+            additional_selectors,
+            additional_annotations,
+        )
+
+        # Make mypy type checking happy that self._patch is a method
+        assert isinstance(self._patch, MethodType)
+        # Ensure this patch is applied during the 'install' and 'upgrade-charm' events
+        self.framework.observe(charm.on.install, self._patch)
+        self.framework.observe(charm.on.upgrade_charm, self._patch)
+
+    def _service_object(
+        self,
+        ports: Sequence[PortDefinition],
+        service_name: str = None,
+        service_type: ServiceType = "ClusterIP",
+        additional_labels: dict = None,
+        additional_selectors: dict = None,
+        additional_annotations: dict = None,
+    ) -> Service:
+        """Creates a valid Service representation.
+
+        Args:
+            ports: a list of tuples of the form (name, port) or (name, port, targetPort)
+                or (name, port, targetPort, nodePort) for every service port. If the 'targetPort'
+                is omitted, it is assumed to be equal to 'port', with the exception of NodePort
+                and LoadBalancer services, where all port numbers have to be specified.
+            service_name: allows setting custom name to the patched service. If none given,
+                application name will be used.
+            service_type: desired type of K8s service. Default value is in line with ServiceSpec's
+                default value.
+            additional_labels: Labels to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_selectors: Selectors to be added to the kubernetes service (by default only
+                "app.kubernetes.io/name" is set to the service name)
+            additional_annotations: Annotations to be added to the kubernetes service.
+
+        Returns:
+            Service: A valid representation of a Kubernetes Service with the correct ports.
+        """
+        if not service_name:
+            service_name = self._app
+        labels = {"app.kubernetes.io/name": self._app}
+        if additional_labels:
+            labels.update(additional_labels)
+        selector = {"app.kubernetes.io/name": self._app}
+        if additional_selectors:
+            selector.update(additional_selectors)
+        return Service(
+            apiVersion="v1",
+            kind="Service",
+            metadata=ObjectMeta(
+                namespace=self._namespace,
+                name=service_name,
+                labels=labels,
+                annotations=additional_annotations,  # type: ignore[arg-type]
+            ),
+            spec=ServiceSpec(
+                selector=selector,
+                ports=[
+                    ServicePort(
+                        name=p[0],
+                        port=p[1],
+                        targetPort=p[2] if len(p) > 2 else p[1],  # type: ignore[misc]
+                        nodePort=p[3] if len(p) > 3 else None,  # type: ignore[arg-type, misc]
+                    )
+                    for p in ports
+                ],
+                type=service_type,
+            ),
+        )
+
+    def _patch(self, _) -> None:
+        """Patch the Kubernetes service created by Juju to map the correct port.
+
+        Raises:
+            PatchFailed: if patching fails due to lack of permissions, or otherwise.
+        """
+        if not self.charm.unit.is_leader():
+            return
+
+        client = Client()
+        try:
+            if self.service_name != self._app:
+                self._delete_and_create_service(client)
+            client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
+        except ApiError as e:
+            if e.status.code == 403:
+                logger.error("Kubernetes service patch failed: `juju trust` this application.")
+            else:
+                logger.error("Kubernetes service patch failed: %s", str(e))
+        else:
+            logger.info("Kubernetes service '%s' patched successfully", self._app)
+
+    def _delete_and_create_service(self, client: Client):
+        service = client.get(Service, self._app, namespace=self._namespace)
+        service.metadata.name = self.service_name  # type: ignore[attr-defined]
+        service.metadata.resourceVersion = service.metadata.uid = None  # type: ignore[attr-defined]   # noqa: E501
+        client.delete(Service, self._app, namespace=self._namespace)
+        client.create(service)
+
+    def is_patched(self) -> bool:
+        """Reports if the service patch has been applied.
+
+        Returns:
+            bool: A boolean indicating if the service patch has been applied.
+        """
+        client = Client()
+        # Get the relevant service from the cluster
+        service = client.get(Service, name=self.service_name, namespace=self._namespace)
+        # Construct a list of expected ports, should the patch be applied
+        expected_ports = [(p.port, p.targetPort) for p in self.service.spec.ports]
+        # Construct a list in the same manner, using the fetched service
+        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
+        return expected_ports == fetched_ports
+
+    @property
+    def _app(self) -> str:
+        """Name of the current Juju application.
+
+        Returns:
+            str: A string containing the name of the current Juju application.
+        """
+        return self.charm.app.name
+
+    @property
+    def _namespace(self) -> str:
+        """The Kubernetes namespace we're running in.
+
+        Returns:
+            str: A string containing the name of the current Kubernetes namespace.
+        """
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
+            return f.read().strip()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -18,6 +18,11 @@ requires:
   ingress:
     interface: ingress
 
+provides:
+  gitlab:
+    interface: gitlab
+    scope: global
+
 containers:
   gitlab:
     resource: gitlab-image

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 # Copyright 2021 Ubuntu
 # See LICENSE file for licensing details.
-name: gitlab-ce-operator
+name: gitlab-ce
 display-name: GitLab CE Operator
 summary: GitLab CE juju operator charm for Kubernetes
 description: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 ops >= 1.2.0
+lightkube
+lightkube-models

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,8 +12,10 @@ develop a new k8s charm using the Operator Framework:
     https://discourse.charmhub.io/t/4208
 """
 
+import json
 import logging
 import os
+import uuid
 
 from ops.charm import CharmBase
 from ops.main import main
@@ -24,6 +26,19 @@ from charms.nginx_ingress_integrator.v0.ingress import IngressRequires
 from charms.observability_libs.v0 import kubernetes_service_patch as k8s_svc_patch
 
 logger = logging.getLogger(__name__)
+
+GITLAB_RELATION_NAME = "gitlab"
+# https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token-programmatically
+RAILS_CREATE_TOKEN = (
+    "token = User.find_by_username('%(username)s').personal_access_tokens"
+    ".create(scopes: [:api], name: '%(token_name)s'); "
+    "token.set_token('%(token)s'); token.save!"
+)
+RAILS_DELETE_TOKEN = (
+    "PersonalAccessToken.find_by_token('%(token)s').revoke!"
+)
+SCHEME_HTTP = "http"
+SCHEME_HTTPS = "https"
 
 
 class GitlabCECharm(CharmBase):
@@ -43,6 +58,12 @@ class GitlabCECharm(CharmBase):
         )
 
         self.ingress = IngressRequires(self, self.ingress_config)
+
+        # gitlab relation lifecycle events:
+        self.framework.observe(self.on[GITLAB_RELATION_NAME].relation_joined,
+                               self._on_gitlab_relation_joined)
+        self.framework.observe(self.on[GITLAB_RELATION_NAME].relation_broken,
+                               self._on_gitlab_relation_broken)
 
     def charm_dir(self):
         """Return the root directory of the current charm"""
@@ -183,6 +204,70 @@ class GitlabCECharm(CharmBase):
         if tls_secret_name:
             ingress_config["tls-secret-name"] = tls_secret_name
         return ingress_config
+
+    def _on_gitlab_relation_joined(self, event):
+        """Handles the gitlab relation joined event.
+
+        When a charm is joining this charm, we can generate a token for it
+        and set connection details into the relation data.
+        """
+        if not self.unit.is_leader():
+            # If we're not the leader, we won't be able to set the
+            # relation data.
+            return
+
+        token = str(uuid.uuid4())
+
+        # NOTE: The gitlab-rails command may take a while to execute, but the
+        # added benefit is that we don't have to worry about having a
+        # user / password for it.
+        rails_cmd = RAILS_CREATE_TOKEN % {
+            "username": "root",
+            "token_name": event.relation.app.name,
+            "token": token,
+        }
+        self._exec_in_container(["gitlab-rails", "runner", rails_cmd])
+
+        api_scheme = (
+            SCHEME_HTTPS if self.config["tls_secret_name"] else SCHEME_HTTP
+        )
+        # The client will not connect to the GitLab service directly, but
+        # through the external URL, which is either:
+        # - self.app.name, in which case there is a Kubernetes Service for it,
+        #   which will map its port 80 to GitLab's actual port.
+        # - self.config["external_url"], in which case the NGINX Ingress will
+        #   have a route for GitLab, which will point towards the right port.
+        creds = {
+            "host": self._external_url,
+            "port": 80,
+            "api-scheme": api_scheme,
+            "access-token": token,
+        }
+        event.relation.data[self.app]["credentials"] = json.dumps(creds)
+
+    def _on_gitlab_relation_broken(self, event):
+        """Handles the gitlab relation broken event.
+
+        When the relation is broken, it means that the related charm no longer
+        requires the generated token. We should remove it.
+        """
+        if not self.unit.is_leader():
+            return
+
+        relation_data = event.relation.data[self.app]
+        if "credentials" not in relation_data:
+            # We didn't set any relation data, nothing to do.
+            return
+
+        creds = json.loads(relation_data["credentials"])
+        rails_cmd = RAILS_DELETE_TOKEN % {"token": creds["access-token"]}
+        self._exec_in_container(["gitlab-rails", "runner", rails_cmd])
+
+    def _exec_in_container(self, cmd):
+        container = self.unit.get_container("gitlab")
+
+        process = container.exec(cmd)
+        process.wait_output()
 
 
 if __name__ == "__main__":

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -3,10 +3,13 @@
 #
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
+import json
+import os
 import unittest
 from unittest import mock
 
-from charm import GitlabCECharm
+import charm
+from ops import model
 from ops.testing import Harness
 
 
@@ -14,9 +17,25 @@ class TestCharm(unittest.TestCase):
 
     @mock.patch("charm.k8s_svc_patch.KubernetesServicePatch", lambda x, y: None)
     def setUp(self, *unused):
-        self.harness = Harness(GitlabCECharm)
+        self.harness = Harness(charm.GitlabCECharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+
+    def _patch(self, obj, method, *args, **kwargs):
+        """Patches the given method and returns its Mock."""
+        patcher = mock.patch.object(obj, method, *args, **kwargs)
+        mock_patched = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        return mock_patched
+
+    def _add_relation(self, relation_name, relator_name, relation_data):
+        """Adds a relation to the charm."""
+        relation_id = self.harness.add_relation(relation_name, relator_name)
+        self.harness.add_relation_unit(relation_id, "%s/0" % relator_name)
+
+        self.harness.update_relation_data(relation_id, relator_name, relation_data)
+        return relation_id
 
     def test_external_url(self):
         self.assertEqual(self.harness.charm._external_url, "gitlab-ce")
@@ -55,3 +74,65 @@ class TestCharm(unittest.TestCase):
             },
         }
         self.assertEqual(self.harness.charm._gitlab_layer(), expected)
+
+    def test_gitlab_relation(self):
+        """Adds a unit test for the gitlab relation.
+
+        When relating a charm to this gitlab-ce charm, this charm should
+        create a new token for the related charm.
+        """
+        # Setting the leader will allow this charm to write into the
+        # relation data.
+        self.harness.set_leader(True)
+
+        # Create the necessary mocks and make the charm Active.
+        os.environ["CHARM_DIR"] = "/foo"
+        self._patch(
+            charm, "open", mock.mock_open(read_data=""), create=True
+        )
+        container = self.harness.model.unit. get_container("gitlab")
+        self._patch(container, "push")
+        self._patch(container, "start")
+
+        self.harness.update_config({"tls_secret_name": "gitlab-tls"})
+
+        self.assertEqual(self.harness.model.unit.status, model.ActiveStatus())
+
+        # Add the gitlab relation and expect that the token is created and set
+        # into the relation data.
+        mock_token = "test-uuid"
+        self._patch(charm.uuid, "uuid4", return_value=mock_token)
+        mock_exec = self._patch(container, "exec")
+
+        self._add_relation(
+            charm.GITLAB_RELATION_NAME, "client-charm", {}
+        )
+
+        rails_cmd = charm.RAILS_CREATE_TOKEN % {
+            "username": "root",
+            "token_name": "client-charm",
+            "token": mock_token,
+        }
+        mock_exec.assert_called_once_with(
+            ["gitlab-rails", "runner", rails_cmd]
+        )
+        relation = self.harness.charm.model.relations[
+            charm.GITLAB_RELATION_NAME
+        ][0]
+        expected_credentials = {
+            "host": self.harness.charm._external_url,
+            "port": 80,
+            "api-scheme": charm.SCHEME_HTTPS,
+            "access-token": mock_token,
+        }
+        expected_data = {"credentials": json.dumps(expected_credentials)}
+        self.assertEqual(expected_data, relation.data[self.harness.charm.app])
+
+        # Remove the relation, assert that the token is revoked.
+        mock_exec.reset_mock()
+        self.harness.remove_relation(relation.id)
+
+        rails_cmd = charm.RAILS_DELETE_TOKEN % {"token": mock_token}
+        mock_exec.assert_called_once_with(
+            ["gitlab-rails", "runner", rails_cmd]
+        )

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -4,13 +4,16 @@
 # Learn more about testing at: https://juju.is/docs/sdk/testing
 
 import unittest
+from unittest import mock
 
 from charm import GitlabCECharm
 from ops.testing import Harness
 
 
 class TestCharm(unittest.TestCase):
-    def setUp(self):
+
+    @mock.patch("charm.k8s_svc_patch.KubernetesServicePatch", lambda x, y: None)
+    def setUp(self, *unused):
         self.harness = Harness(GitlabCECharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -14,3 +14,41 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(GitlabCEOperatorCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
+
+    def test_external_url(self):
+        self.assertEqual(self.harness.charm._external_url, "gitlab-ce")
+
+    def test_ingress_config(self):
+        expected = {
+            "service-hostname": "gitlab-ce",
+            "service-name": "gitlab-ce",
+            "service-port": 80,
+        }
+        self.assertEqual(self.harness.charm.ingress_config, expected)
+        # And now test with a TLS secret name set.
+        self.harness.disable_hooks()
+        self.harness.update_config({"tls_secret_name": "gitlab-tls"})
+        expected["tls-secret-name"] = "gitlab-tls"
+        self.assertEqual(self.harness.charm.ingress_config, expected)
+
+    def test_gitlab_layer(self):
+        conf = ("external_url 'http://gitlab-ce:80'; "
+                "alertmanager['enable']=false; "
+                "prometheus['enable']=false; "
+                "gitlab_rails['smtp_enable']=true; "
+                "gitlab_rails['smtp_enable_starttls_auto']=true; "
+                "gitlab_rails['smtp_tls']=false")
+        expected = {
+            "summary": "gitlab layer",
+            "description": "pebble config layer for gitlab",
+            "services": {
+                "gitlab": {
+                    "override": "replace",
+                    "summary": "gitlab",
+                    "command": "bash -c \"/assets/gitlab-install\"",
+                    "startup": "enabled",
+                    "environment": {"GITLAB_OMNIBUS_CONFIG": conf},
+                }
+            },
+        }
+        self.assertEqual(self.harness.charm._gitlab_layer(), expected)


### PR DESCRIPTION
Adds the gitlab provider relation into the metadata.yaml file, allowing this charm to create a token for any new gitlab requirer.
When that relation is broken, that token will be removed.

Using gitlab-rails [1] for creating the token, which has the benefit of not needing to know the user / password in order to generate a usable token.

The following fields are set in the related gitlab relation data, in the credentials field:

- ``host``: either the charm application name, or the configured ``external_url``. If it's the application name, Juju creates a Kubernetes Service for it, (which points towards the right port due to the ``KubernetesServicePatch``) which is resolvable and usable internally in the Kubernetes Cluster. If an external URL / hostname is used, the expectation that it is resolvable.
- ``port``: always ``80``. If the host is the application name, the Kubernetes Service will be used, which will point towards the right port. If the host is the configured ``external_url``, then the related ``nginx-ingress-integrator`` charm will have already set up an Ingress Route for it.
- ``api_scheme``: ``https`` if the config option ``tls_secret_name`` is set, ``http`` otherwise.
- ``access-token``: The newly generated token for that relation.

Depends-On: https://github.com/mkissam/charm-gitlab-ce/pull/1

[1] https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token-programmatically